### PR TITLE
Fixed links

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See the Acronyms Seriously Suck rule: https://gist.github.com/klaaspieter/12cd68
 
 ## Basisregistratie attributes
 - Nummeraanduiding - Ambtenaars voor adres
-- [Alle afkortingen van attributen in basisregistraties](https://dokuwiki.datapunt.amsterdam.nl/doku.php?id=start:datasets:basisregistratie:afkortingen_registraties) alleen intern te bekijken via de dokuwiki.
+- [Alle afkortingen van attributen in basisregistraties](https://wiki.data.amsterdam.nl/doku.php?id=start:datasets:basisregistratie:afkortingen_registraties) alleen intern te bekijken via de dokuwiki.
 
 ## Statistical Data
 - [BBGA](https://data.amsterdam.nl/#?dte=dcatd%2Fdatasets%2Fbasisbestand-gebieden-amsterdam-bbga&dtfs=T&dsf=groups::bevolking&mpb=topografie&mpz=11&mpv=52.3731081:4.8932945) - Basis Bestand Gebieden Amsterdam
@@ -78,7 +78,7 @@ See the Acronyms Seriously Suck rule: https://gist.github.com/klaaspieter/12cd68
 - WPD - Werkproces voor Privacygerelateerde Dataleveringen (Stedelijke intake)
 
 ## Documentation
-- [Dokuwiki](https://dokuwiki.datapunt.amsterdam.nl/) - Interne Wiki met achtergrondinformatie projecten Datapunt
+- [Dokuwiki](https://wiki.data.amsterdam.nl/) - Interne Wiki met achtergrondinformatie projecten Datapunt
 - PSA - Project Start Architectuur document uit PPM processen voor bijvoorbeeld inkoop nieuwe software.
 - [WMO](https://www.rijksoverheid.nl/onderwerpen/zorg-en-ondersteuning-thuis/wmo-2015)
 
@@ -86,11 +86,11 @@ See the Acronyms Seriously Suck rule: https://gist.github.com/klaaspieter/12cd68
 - [CD](https://nl.wikipedia.org/wiki/Continuous_delivery) Continuous Delivery
 - [CI](https://en.wikipedia.org/wiki/Continuous_integration) Continuous Integration
 - [GGW](https://www.amsterdam.nl/bestuur-organisatie/volg-beleid/gebiedsgericht/artikelen/gebiedsgericht/) - GebiedsGericht Werken
-- [TMLO](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=2ahUKEwi4wav0pu3fAhUB-aQKHV5tBToQFjAAegQIChAB&url=https%3A%2F%2Fwww.archief2020.nl%2Fnieuws%2Ftoepassingsprofiel-metadatering-lokale-overheden&usg=AOvVaw0RlTyWc4GdgL8ClI1pUu8y) - Toepassingsprofiel Metadatering Lokale Overheden
+- [TMLO](https://www.nationaalarchief.nl/archiveren/kennisbank/tmlo) - Toepassingsprofiel Metadatering Lokale Overheden
 - [BIM](https://hetnationaalbimplatform.nl/wat-is-bim.php)- Building Information Model
 - [PPM](https://leansixsigmatools.nl/projectportfolio-management) - Project Portfolio Management
-- DSU - Daily Stand Up
-- MVP - Minimal viable product
+- [DSU](https://agilescrumgroup.nl/5-tips-goede-daily-stand-up-meeting) - Daily Stand Up
+- [MVP](https://agilescrumgroup.nl/minimum-viable-product) - Minimal viable product
 
 ## Technology
 - [API](https://nl.wikipedia.org/wiki/Application_programming_interface) - Application program interface, computer accessible version of data in the system. 


### PR DESCRIPTION
Links to the internal dokuwiki are now to the new site.
Also there were some missing links which I could add.